### PR TITLE
Add continuous bookmark scanning

### DIFF
--- a/modules/constants.py
+++ b/modules/constants.py
@@ -57,7 +57,8 @@ MODE_MAP["CW"] = "CW",
 MODE_MAP["CWL"] = "CW-L",
 MODE_MAP["CWU"] = "CW-U"
 
-SUPPORTED_SCANNING_ACTIONS = ("start")
+SUPPORTED_SCANNING_ACTIONS = ("start",
+                              "stop")
 
 SUPPORTED_SCANNING_MODES = ("bookmarks",
                             "frequency")

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -15,6 +15,13 @@ License: MIT License
 
 Copyright (c) 2014 Rafael Marmelo
 Copyright (c) 2015 Simone Marzona
+
+TAS - Tim Sweeney - mainetim@gmail.com
+
+2016/02/16 - TAS - Added code to support continuous bookmark scanning.
+                   Temporarily disabled freq activity logging and notification.
+                   Scan call now a separate thread.
+                   Added a "stop" button.
 """
 
 # import modules
@@ -39,6 +46,7 @@ from Tkinter import Text
 from Tkinter import LabelFrame
 from Tkinter import Label
 import tkMessageBox
+import threading
 
 # logging configuration
 logger = logging.getLogger(__name__)
@@ -59,7 +67,8 @@ class RigRemote(ttk.Frame):  #pragma: no cover
         self.cbb_mode.current(0)
         # bookmarks loading on start
         self.bookmark("load", ",")
-
+        self.scan_thread = None
+        self.scanning = None
 
     def build(self, ac):  #pragma: no cover
         """Build and initialize the GUI widgets.
@@ -400,6 +409,16 @@ class RigRemote(ttk.Frame):  #pragma: no cover
                                           command=self.bookmark_start,
                                           )
         self.book_scan_start.grid(row=17,
+                                  column=2,
+                                  columnspan=1,
+                                  padx=2,
+                                  sticky=tk.W)
+
+        self.book_scan_stop = ttk.Button(self.book_scanning_menu,
+                                          text="Stop",
+                                          command=self.bookmark_stop,
+                                          )
+        self.book_scan_stop.grid(row=17,
                                   column=3,
                                   columnspan=1,
                                   padx=2,
@@ -558,6 +577,13 @@ class RigRemote(ttk.Frame):  #pragma: no cover
 
         self._scan("bookmarks", "start")
 
+    def bookmark_stop(self):  #pragma: no cover
+        """Wrapper around _scan() that starts a scan from bookmarks.
+
+        """
+
+        self._scan("bookmarks", "stop")
+
     def frequency_start(self):  #pragma: no cover
         """Wrapper around _scan() that starts a scan from a frequency range.
 
@@ -582,6 +608,17 @@ class RigRemote(ttk.Frame):  #pragma: no cover
             logger.error("Supported actions:{}".format(SUPPORTED_SCANNING_ACTIONS))
             raise UnsupportedScanningConfigError
 
+        if action.lower() == "stop" and self.scan_thread != None:
+            self.scanning.terminate()
+            self.scan_thread.join()
+            self.scan_thread = None
+            return
+        
+        if (action.lower() == "start" and self.scan_thread != None) :
+            return
+        if (action.lower() == "stop" and self.scan_thread == None) :
+            return
+
         bookmark_list = []
         for item in self.tree.get_children():
             values = self.tree.item(item).get('values')
@@ -598,26 +635,30 @@ class RigRemote(ttk.Frame):  #pragma: no cover
                                      delay,
                                      interval,
                                      sgn_level)
-        scanning = Scanning()
-        task = scanning.scan(scanning_task)
-        if (task.mode.lower() == "bookmarks" and 
-            len(task.new_bookmark_list) > 0):
-            message = self._new_activity_message(task.new_bookmark_list)
-            tkMessageBox.showinfo("New activity found", message,
-                                   parent=self)
+        self.scanning = Scanning()
+        self.scan_thread = threading.Thread(target = self.scanning.scan, 
+                                       args = (scanning_task,))
+        self.scan_thread.start()
 
-        if (task.mode.lower() == "frequency" and 
-            len(task.new_bookmark_list) > 0 and 
-            (len(self.ckb_auto_bookmark.state()) == 1 and
-            self.ckb_auto_bookmark.state()== ('selected',))):
-                self._add_new_bookmarks(task.new_bookmark_list)
+        # task = scanning.scan(scanning_task)
+        # if (task.mode.lower() == "bookmarks" and 
+        #     len(task.new_bookmark_list) > 0):
+        #     message = self._new_activity_message(task.new_bookmark_list)
+        #     tkMessageBox.showinfo("New activity found", message,
+        #                            parent=self)
 
-        elif (task.mode.lower() == "frequency" and 
-              len(task.new_bookmark_list) > 0 and 
-              len(self.ckb_auto_bookmark.state()) == 0):
-                message = self._new_activity_message(task.new_bookmark_list)
-                tkMessageBox.showinfo("New activity found", message,
-                                       parent=self)
+        # if (task.mode.lower() == "frequency" and 
+        #     len(task.new_bookmark_list) > 0 and 
+        #     (len(self.ckb_auto_bookmark.state()) == 1 and
+        #     self.ckb_auto_bookmark.state()== ('selected',))):
+        #         self._add_new_bookmarks(task.new_bookmark_list)
+
+        # elif (task.mode.lower() == "frequency" and 
+        #       len(task.new_bookmark_list) > 0 and 
+        #       len(self.ckb_auto_bookmark.state()) == 0):
+        #         message = self._new_activity_message(task.new_bookmark_list)
+        #         tkMessageBox.showinfo("New activity found", message,
+        #                                parent=self)
 
     def _new_activity_message(self, nbl):
         """Provides a little formatting from the new bookmark list.


### PR DESCRIPTION
This branch modifies the bookmark scanning functionality to create
something along the lines of a "police scanner". Bookmarks are
continuously scanned until the "stop" button is pressed by creating
a separate scan thread. Logging of activity has been temporarily disabled.
Additional "scanner" functionality (lockouts, better pause and resume) could
be added, along with recording of received transmissions.

Don't know if this will be of any use to you, but thought I'd kick it back anyway, and
say thanks!
